### PR TITLE
Use correct attributes for a Payout as per API

### DIFF
--- a/lib/Business/GoCardless/Payout.pm
+++ b/lib/Business/GoCardless/Payout.pm
@@ -19,23 +19,29 @@ extends 'Business::GoCardless::Resource';
 =head1 ATTRIBUTES
 
     amount
-    app_ids
-    bank_reference
+    arrival_date
     created_at
+    currency
+    deducted_fees
     id
-    paid_at
-    transaction_fees
+    links
+    payout_type
+    reference
+    status
 
 =cut
 
 has [ qw/
     amount
-    app_ids
-    bank_reference
+    arrival_date
     created_at
+    currency
+    deducted_fees
     id
-    paid_at
-    transaction_fees
+    links
+    payout_type
+    reference
+    status
 / ] => (
     is => 'rw',
 );


### PR DESCRIPTION
As per the API at https://developer.gocardless.com/api-reference/#core-endpoints-payouts

Added:
- currency
- links
- payout_type
- status

Removed:
- app_ids

Renamed:
- bank_reference → reference
- paid_at → arrival_date
- transaction_fees → deducted_fees

Do you want the old names of the renamed attributes to still be available as aliases?