### PR TITLE
The previous commit uses postfix dereference, introduced with v5.20.0

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ WriteMakefile(
     VERSION_FROM     => 'lib/Business/GoCardless.pm',
     AUTHOR           => 'Lee Johnson <leejo@cpan.org>',
     LICENSE          => 'perl',
-    MIN_PERL_VERSION => '5.10.1',
+    MIN_PERL_VERSION => '5.20.0',
     PREREQ_PM => {
         'Moo'                  => 1.006,
         'Carp'                 => 0, # Carp was first released with perl 5

--- a/t/business/gocardless/pro.t
+++ b/t/business/gocardless/pro.t
@@ -3,9 +3,10 @@
 use strict;
 use warnings;
 use utf8;
+use feature qw/ postderef /;
 
 use Test::Most;
-use Test::Deep;
+no warnings qw/ experimental::postderef /;
 use Test::MockObject;
 use Test::Exception;
 use JSON;


### PR DESCRIPTION
Hence bump the MIN_PERL_VERSION to reflect this, and add the relevant `use feature` and `no warnings` to enable warning free use of this on older perls.